### PR TITLE
Add Foldable plugin

### DIFF
--- a/content/pages/docs/plugins/foldable.mdown
+++ b/content/pages/docs/plugins/foldable.mdown
@@ -23,3 +23,5 @@ This plugin allows you to place a `~~fold~~` in your content, and will set the s
 See the README on the [GitHub page](https://github.com/MicahChalmer/nesta-plugin-foldable).
 
 The plugin is available on rubygems, so just add `gem "nesta-plugin-foldable"` to your Gemfile and enjoy.
+
+Written by Micah Chalmer


### PR DESCRIPTION
I wrote a plugin called "Foldable" that I think would be of general interest.  The idea is that, if you want to use the beginning of the body content as the summary, you shouldn't have to write the same content twice in both the metadata and the body.  Instead, just place a "fold" at the point where you want the summary to stop.  I've seen this pattern in enough blogs that I'm guessing somebody else might find it handy, so I put it up on rubygems.  As per the "writing nesta plugins" instructions, I've added a page for it for the plugin directory, should you choose to merge it.
